### PR TITLE
[IMP] purchase_reorder_control: Filter purchasable products for stockwarehouse.orderpoint

### DIFF
--- a/purchase_reorder_control/models/stock_warehouse_orderpoint.py
+++ b/purchase_reorder_control/models/stock_warehouse_orderpoint.py
@@ -8,6 +8,11 @@ from odoo.exceptions import UserError
 class StockWarehouseOrderpoint(models.Model):
     _inherit = "stock.warehouse.orderpoint"
 
+    def _get_orderpoint_products(self):
+        """Override to exclude unpurchaseable products"""
+        products = super()._get_orderpoint_products()
+        return products.filtered(lambda p: p.purchase_ok)
+
     @api.model_create_multi
     def create(self, vals_list):
         rules = super().create(vals_list)


### PR DESCRIPTION
Base  PR: https://github.com/OCA/purchase-workflow/pull/2236

When we  "Replish" the following methods are `_get_orderpoint_action => _get_orderpoint_products` in order to create  `stockwarehouse.orderpoint`.

Standard is getting unpurchasable products:
```
def _get_orderpoint_products(self):
        return self.env['product.product'].search([('type', '=', 'product'), ('stock_move_ids', '!=', False)])
```

TODO
Override `_get_orderpoint_products`  to exclude unpurchaseable products
